### PR TITLE
metrics: update nlean column to reflect current coverage

### DIFF
--- a/metrics.md
+++ b/metrics.md
@@ -36,11 +36,11 @@
 
 | Name   | Type  | Usage | Sample collection event | Labels | Buckets | EthLambda | Grandine | Lantern  | Lighthouse | Nlean | Peam | Qlean    | Ream     | Zeam     |
 |--------|-------|-------|-------------------------|--------|---------|-----------|----------|----------|------------|-------|------|----------|----------|----------|
-| `lean_block_aggregated_payloads` | Histogram | Number of `aggregated_payloads` in a block | On block production | | 1, 2, 4, 8, 16, 32, 64, 128 | □ | □ | □ | □ | □ | □ | □ | □ | □ |
-| `lean_block_building_payload_aggregation_time_seconds` | Histogram | Time taken to build `aggregated_payloads` during block building | On block production | | 0.1, 0.25, 0.5, 0.75, 1, 2, 3, 4 | □ | □ | □ | □ | □ | □ | □ | □ | □ |
-| `lean_block_building_time_seconds` | Histogram | Time taken to build a block | On block production | | 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 0.75, 1 | □ | □ | □ | □ | □ | □ | □ | □ | □ |
-| `lean_block_building_success_total` | Counter | Successful block builds | On block production | | | □ | □ | □ | □ | □ | □ | □ | □ | □ |
-| `lean_block_building_failures_total` | Counter | Failed block builds (exception in build_block) | On block production failure | | | □ | □ | □ | □ | □ | □ | □ | □ | □ |
+| `lean_block_aggregated_payloads` | Histogram | Number of `aggregated_payloads` in a block | On block production | | 1, 2, 4, 8, 16, 32, 64, 128 | □ | □ | □ | □ | ✅ | □ | □ | □ | □ |
+| `lean_block_building_payload_aggregation_time_seconds` | Histogram | Time taken to build `aggregated_payloads` during block building | On block production | | 0.1, 0.25, 0.5, 0.75, 1, 2, 3, 4 | □ | □ | □ | □ | ✅ | □ | □ | □ | □ |
+| `lean_block_building_time_seconds` | Histogram | Time taken to build a block | On block production | | 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 0.75, 1 | □ | □ | □ | □ | ✅ | □ | □ | □ | □ |
+| `lean_block_building_success_total` | Counter | Successful block builds | On block production | | | □ | □ | □ | □ | ✅ | □ | □ | □ | □ |
+| `lean_block_building_failures_total` | Counter | Failed block builds (exception in build_block) | On block production failure | | | □ | □ | □ | □ | ✅ | □ | □ | □ | □ |
 
 ## Fork-Choice Metrics
 
@@ -51,7 +51,7 @@
 | `lean_safe_target_slot` | Gauge | Safe target slot | On safe target update | | | ✅ | □ | ✅ | □ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | `lean_fork_choice_block_processing_time_seconds` | Histogram | Time taken to process block | On fork choice process block | | 0.005, 0.01, 0.025, 0.05, 0.1, 1, 1.25, 1.5, 2, 4 | ✅ | □ | 📝 | □ | ✅ | ✅ | ✅ | 📝 | 📝 |
 | `lean_attestations_valid_total` | Counter | Total number of valid attestations | On validate attestation | | | ✅ | □ | ✅ | □ | ✅ | ✅ | ✅ | □ | 📝 |
-| `lean_attestations_invalid_total` | Counter | Total number of invalid attestations | On validate attestation | | | ✅ | □ | ✅ | □ | □ | ✅ | ✅ | □ | 📝 |
+| `lean_attestations_invalid_total` | Counter | Total number of invalid attestations | On validate attestation | | | ✅ | □ | ✅ | □ | ✅ | ✅ | ✅ | □ | 📝 |
 | `lean_attestation_validation_time_seconds` | Histogram | Time taken to validate attestation | On validate attestation | | 0.005, 0.01, 0.025, 0.05, 0.1, 1 | ✅ | □ | ✅ | □ | ✅ | ✅ | ✅ | □ | ✅ |
 | `lean_fork_choice_reorgs_total` | Counter | Total number of fork choice reorgs | On fork choice reorg | | | ✅ | □ | ✅ | □ | ✅ | ✅ | ✅ | □ | ✅ |
 | `lean_fork_choice_reorg_depth` | Histogram | Depth of fork choice reorgs (in blocks) | On fork choice reorg | | 1, 2, 3, 5, 7, 10, 20, 30, 50, 100 | ✅ | □ | ✅ | □ | ✅ | ✅ | ✅ | □ | ✅ |
@@ -59,7 +59,7 @@
 | `lean_latest_new_aggregated_payloads` | Gauge | Number of new aggregated payload items | On `latest_new_aggregated_payloads` update | | | ✅ | □ | 📝 | □ | ✅ | ✅ | □ | ✅ | □ |
 | `lean_latest_known_aggregated_payloads` | Gauge | Number of known aggregated payload items | On `latest_known_aggregated_payloads` update | | | ✅ | □ | 📝 | □ | ✅ | ✅ | □ | ✅ | □ |
 | `lean_committee_signatures_aggregation_time_seconds` | Histogram | Time taken to aggregate committee signatures | On committee signatures aggregation | | 0.05, 0.1, 0.25, 0.5, 0.75, 1, 2, 3, 4 | ✅ | □ | ✅ | □ | ✅ | ✅ | ✅ | ✅ | □ |
-| `lean_node_sync_status` | Gauge | Node sync status | On node sync status change | status=idle,syncing,synced | | □ | □ | □ | □ | □ | □ | □ | □ | □ |
+| `lean_node_sync_status` | Gauge | Node sync status | On node sync status change | status=idle,syncing,synced | | □ | □ | □ | □ | ✅ | □ | □ | □ | □ |
 
 ## State Transition Metrics
 
@@ -67,8 +67,8 @@
 |--------|-------|-------|-------------------------|--------|---------|-----------|----------|----------|------------|-------|------|----------|----------|----------|
 | `lean_latest_justified_slot` | Gauge | Latest justified slot | On state transition | | | ✅ | □ | ✅ | □ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | `lean_latest_finalized_slot` | Gauge | Latest finalized slot | On state transition | | | ✅ | □ | ✅ | □ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| `lean_justified_slot` | Gauge | Current justified slot | On state transition | | | □ | □ | □ | □ | □ | ✅ | □ | ✅ | □ |
-| `lean_finalized_slot` | Gauge | Current finalized slot | On state transition | | | □ | □ | □ | □ | □ | ✅ | □ | ✅ | □ |
+| `lean_justified_slot` | Gauge | Current justified slot | On state transition | | | □ | □ | □ | □ | ✅ | ✅ | □ | ✅ | □ |
+| `lean_finalized_slot` | Gauge | Current finalized slot | On state transition | | | □ | □ | □ | □ | ✅ | ✅ | □ | ✅ | □ |
 | `lean_finalizations_total` | Counter | Total number of finalization attempts | On finalization attempt | result=success,error | | ✅ | □ | ✅ | □ | ✅ | ✅ | □ | ✅ | 📝 |
 | `lean_state_transition_time_seconds` | Histogram | Time to process state transition | On state transition | | 0.25, 0.5, 0.75, 1, 1.25, 1.5, 2, 2.5, 3, 4 | ✅ | □ | ✅ | □ | ✅ | ✅ | ✅ | 📝 | ✅ |
 | `lean_state_transition_slots_processed_total` | Counter | Total number of processed slots | On state transition process slots | | | ✅ | □ | ✅ | □ | ✅ | ✅ | ✅ | ✅ | ✅ |
@@ -83,7 +83,7 @@
 |--------|-------|-------|-------------------------|--------|---------|-----------|----------|----------|------------|-------|------|----------|----------|----------|
 | `lean_validators_count` | Gauge | Number of validators managed by a node | On scrape |  | | ✅ | □ | ✅ | □ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | `lean_is_aggregator` | Gauge | Validator's `is_aggregator` status. True=1, False=0 | On node start |  | | ✅ | □ | ✅ | □ | ✅ | ✅ | ✅ | ✅ | □ |
-| `lean_attestations_production_time_seconds` | Histogram | Time taken to produce attestation | On attestation production | | 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 0.75, 1 | □ | □ | □ | □ | □ | □ | □ | □ | □ |
+| `lean_attestations_production_time_seconds` | Histogram | Time taken to produce attestation | On attestation production | | 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 0.75, 1 | □ | □ | □ | □ | ✅ | □ | □ | □ | □ |
 
 ## Network Metrics
 
@@ -94,6 +94,6 @@
 | `lean_peer_disconnection_events_total` | Counter | Total number of peer disconnection events | On peer disconnection | direction=inbound,outbound<br>reason=timeout,remote_close,local_close,error | | ✅ | □ | ✅ | □ | ✅ | ✅ | 📝 | 📝 | ✅ |
 | `lean_attestation_committee_subnet` | Gauge | Node's attestation committee subnet | On node start | | | □ | □ | 📝 | □ | ✅ | ✅ | ✅ | □ | □ |
 | `lean_attestation_committee_count` | Gauge | Number of attestation committees (ATTESTATION_COMMITTEE_COUNT) | On node start | | | ✅ | □ | 📝 | □ | ✅ | ✅ | ✅ | ✅ | □ |
-| `lean_gossip_block_size_bytes` | Histogram | Bytes size of a gossip block message | On gossip block received | | 10000, 50000, 100000, 250000, 500000, 1000000, 2000000, 5000000 | □ | □ | □ | □ | □ | □ | □ | □ | □ |
-| `lean_gossip_attestation_size_bytes` | Histogram | Bytes size of a gossip attestation message | On gossip attestation received | | 512, 1024, 2048, 4096, 8192, 16384 | □ | □ | □ | □ | □ | □ | □ | □ | □ |
-| `lean_gossip_aggregation_size_bytes` | Histogram | Bytes size of a gossip aggregated attestation message | On gossip aggregate_and_proof received | | 1024, 4096, 16384, 65536, 131072, 262144, 524288, 1048576 | □ | □ | □ | □ | □ | □ | □ | □ | □ |
+| `lean_gossip_block_size_bytes` | Histogram | Bytes size of a gossip block message | On gossip block received | | 10000, 50000, 100000, 250000, 500000, 1000000, 2000000, 5000000 | □ | □ | □ | □ | ✅ | □ | □ | □ | □ |
+| `lean_gossip_attestation_size_bytes` | Histogram | Bytes size of a gossip attestation message | On gossip attestation received | | 512, 1024, 2048, 4096, 8192, 16384 | □ | □ | □ | □ | ✅ | □ | □ | □ | □ |
+| `lean_gossip_aggregation_size_bytes` | Histogram | Bytes size of a gossip aggregated attestation message | On gossip aggregate_and_proof received | | 1024, 4096, 16384, 65536, 131072, 262144, 524288, 1048576 | □ | □ | □ | □ | ✅ | □ | □ | □ | □ |


### PR DESCRIPTION
## Summary

nlean (ghcr.io/nleaneth/nlean v0.3.9-devnet4) now implements the thirteen metrics that were previously marked \`□\` in its column. Flipping them to \`✅\` in the spec so dashboards and coverage tracking stay honest.

### What changed per section
- **Block Production**: \`lean_block_aggregated_payloads\`, \`lean_block_building_payload_aggregation_time_seconds\`, \`lean_block_building_time_seconds\`, \`lean_block_building_success_total\`, \`lean_block_building_failures_total\`
- **Fork-Choice**: \`lean_attestations_invalid_total\` (already implemented — entry was stale), \`lean_node_sync_status\` (one-hot gauge with \`status=idle,syncing,synced\`)
- **State Transition**: \`lean_justified_slot\`, \`lean_finalized_slot\` (mirrored alongside the \`_latest_\` variants)
- **Validator**: \`lean_attestations_production_time_seconds\`
- **Network**: \`lean_gossip_block_size_bytes\`, \`lean_gossip_attestation_size_bytes\`, \`lean_gossip_aggregation_size_bytes\`

Landed in nleanEth/nlean b65669a; bucket / label choices match this spec verbatim.

## Test plan
- [x] nlean unit + spec suites pass (852/853, 1 unrelated skip)