### PR TITLE
Add gossip mesh peers metric

### DIFF
--- a/dashboards/lean-ethereum-clients-dashboard.json
+++ b/dashboards/lean-ethereum-clients-dashboard.json
@@ -3,7 +3,7 @@
   "kind": "Dashboard",
   "metadata": {
     "name": "lean-ethereum-clients-dashboard",
-    "generation": 4,
+    "generation": 5,
     "creationTimestamp": "2026-04-19T14:41:11Z",
     "labels": {},
     "annotations": {}
@@ -1024,6 +1024,246 @@
                       }
                     },
                     "refId": "B",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "timeseries",
+            "version": "13.0.1",
+            "spec": {
+              "options": {
+                "annotations": {
+                  "clustering": -1,
+                  "multiLane": false
+                },
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "none"
+                }
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      },
+                      {
+                        "value": 80,
+                        "color": "red"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 0,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-108": {
+        "kind": "Panel",
+        "spec": {
+          "id": 108,
+          "title": "Gossip mesh peers per node",
+          "description": "",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": " sum by (network, job, instance) (lean_gossip_mesh_peers{network=~\"$network\", job=~\"$job\", instance=~\"$instance\"})",
+                        "interval": "",
+                        "legendFormat": "{{job}}",
+                        "range": true
+                      },
+                      "labels": {
+                        "grafana.app/export-label": "prometheus-1"
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "timeseries",
+            "version": "13.0.1",
+            "spec": {
+              "options": {
+                "annotations": {
+                  "clustering": -1,
+                  "multiLane": false
+                },
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "none"
+                }
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      },
+                      {
+                        "value": 80,
+                        "color": "red"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 0,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-109": {
+        "kind": "Panel",
+        "spec": {
+          "id": 109,
+          "title": "Gossip mesh peers per node (detailed)",
+          "description": "",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": " sum by (network, job, instance, client) (lean_gossip_mesh_peers{network=~\"$network\", job=~\"$job\", instance=~\"$instance\", client!=\"\"})",
+                        "instant": false,
+                        "interval": "",
+                        "legendFormat": "{{job}} - {{client}}",
+                        "range": true
+                      },
+                      "labels": {
+                        "grafana.app/export-label": "prometheus-1"
+                      }
+                    },
+                    "refId": "A",
                     "hidden": false
                   }
                 }
@@ -8403,7 +8643,7 @@
                         "height": 9,
                         "element": {
                           "kind": "ElementReference",
-                          "name": "panel-55"
+                          "name": "panel-108"
                         }
                       }
                     },
@@ -8412,6 +8652,32 @@
                       "spec": {
                         "x": 12,
                         "y": 9,
+                        "width": 12,
+                        "height": 9,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-109"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 0,
+                        "y": 18,
+                        "width": 12,
+                        "height": 9,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-55"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 12,
+                        "y": 18,
                         "width": 12,
                         "height": 9,
                         "element": {

--- a/metrics.md
+++ b/metrics.md
@@ -89,9 +89,10 @@
 
 | Name   | Type  | Usage | Sample collection event | Labels | Buckets | EthLambda | Grandine | Lantern  | Lighthouse | Nlean | Peam | Qlean    | Ream     | Zeam     |
 |--------|-------|-------|-------------------------|--------|---------|-----------|----------|----------|------------|-------|------|----------|----------|----------|
-| `lean_connected_peers` | Gauge | Number of connected peers | On scrape | client=ethlambda,grandine,lantern,lighthouse,qlean,ream,zeam | | ✅ | □ | ✅ | □ | ✅ | ✅ | ✅ | ✅ | 📝 |
+| `lean_connected_peers` | Gauge | Number of connected peers | On scrape | client=\<name\>_\<N\>\|unknown (ex. zeam_0) | | ✅ | □ | ✅ | □ | ✅ | ✅ | ✅ | ✅ | 📝 |
 | `lean_peer_connection_events_total` | Counter | Total number of peer connection events | On peer connection | direction=inbound,outbound<br>result=success,timeout,error | | ✅ | □ | ✅ | □ | ✅ | ✅ | ✅ | 📝 | 📝 |
 | `lean_peer_disconnection_events_total` | Counter | Total number of peer disconnection events | On peer disconnection | direction=inbound,outbound<br>reason=timeout,remote_close,local_close,error | | ✅ | □ | ✅ | □ | ✅ | ✅ | 📝 | 📝 | ✅ |
+| `lean_gossip_mesh_peers` | Gauge | Number of peers in the gossipsub mesh | On scrape | client=\<name\>_\<N\>\|unknown (ex. zeam_0) | | □ | □ | □ | □ | □ | □ | □ | □ | □ |
 | `lean_attestation_committee_subnet` | Gauge | Node's attestation committee subnet | On node start | | | □ | □ | 📝 | □ | ✅ | ✅ | ✅ | □ | □ |
 | `lean_attestation_committee_count` | Gauge | Number of attestation committees (ATTESTATION_COMMITTEE_COUNT) | On node start | | | ✅ | □ | 📝 | □ | ✅ | ✅ | ✅ | ✅ | □ |
 | `lean_gossip_block_size_bytes` | Histogram | Bytes size of a gossip block message | On gossip block received | | 10000, 50000, 100000, 250000, 500000, 1000000, 2000000, 5000000 | □ | □ | □ | □ | □ | □ | □ | □ | □ |

--- a/metrics.md
+++ b/metrics.md
@@ -90,10 +90,10 @@
 
 | Name   | Type  | Usage | Sample collection event | Labels | Buckets | EthLambda | Grandine | Lantern  | Lighthouse | Nlean | Peam | Qlean    | Ream     | Zeam     |
 |--------|-------|-------|-------------------------|--------|---------|-----------|----------|----------|------------|-------|------|----------|----------|----------|
-| `lean_connected_peers` | Gauge | Number of connected peers | On scrape | client=\<name\>_\<N\>\|unknown (ex. zeam_0) | | ✅ | □ | ✅ | □ | ✅ | ✅ | ✅ | ✅ | 📝 |
+| `lean_connected_peers` | Gauge | Number of connected peers | On scrape | client=<name>_<N>|unknown (ex. zeam_0) | | ✅ | □ | ✅ | □ | ✅ | ✅ | ✅ | ✅ | 📝 |
 | `lean_peer_connection_events_total` | Counter | Total number of peer connection events | On peer connection | direction=inbound,outbound<br>result=success,timeout,error | | ✅ | □ | ✅ | □ | ✅ | ✅ | ✅ | 📝 | 📝 |
 | `lean_peer_disconnection_events_total` | Counter | Total number of peer disconnection events | On peer disconnection | direction=inbound,outbound<br>reason=timeout,remote_close,local_close,error | | ✅ | □ | ✅ | □ | ✅ | ✅ | 📝 | 📝 | ✅ |
-| `lean_gossip_mesh_peers` | Gauge | Number of peers in the gossipsub mesh | On scrape | client=\<name\>_\<N\>\|unknown (ex. zeam_0) | | □ | □ | □ | □ | □ | □ | □ | □ | □ |
+| `lean_gossip_mesh_peers` | Gauge | Number of peers in the gossipsub mesh | On scrape | client=<name>_<N>|unknown (ex. zeam_0) | | □ | □ | □ | □ | □ | □ | □ | □ | □ |
 | `lean_attestation_committee_subnet` | Gauge | Node's attestation committee subnet | On node start | | | □ | □ | 📝 | □ | ✅ | ✅ | ✅ | □ | □ |
 | `lean_attestation_committee_count` | Gauge | Number of attestation committees (ATTESTATION_COMMITTEE_COUNT) | On node start | | | ✅ | □ | 📝 | □ | ✅ | ✅ | ✅ | ✅ | □ |
 | `lean_gossip_block_size_bytes` | Histogram | Bytes size of a gossip block message | On gossip block received | | 10000, 50000, 100000, 250000, 500000, 1000000, 2000000, 5000000 | □ | □ | □ | □ | □ | □ | □ | □ | □ |


### PR DESCRIPTION
- Adds `lean_gossip_mesh_peers` metric to Network Metrics. 
- Updates the client label description for `lean_connected_peers` and `lean_gossip_mesh_peers`  from an enumerated list of client names to a `<name>_<N>|unknown` pattern to better reflect dynamic node instance naming.