### PR TITLE
metrics.md: add lean_aggregator_skipped_total + update aggregated_signatures_building_time status

### DIFF
--- a/metrics.md
+++ b/metrics.md
@@ -29,7 +29,7 @@
 | `lean_pq_sig_aggregated_signatures_valid_total`| Counter | Total number of valid aggregated signatures | On aggregated signature verification | | | ✅ | □ | ✅ | □ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | `lean_pq_sig_aggregated_signatures_invalid_total`| Counter | Total number of invalid aggregated signatures | On aggregated signature verification | | | □ | □ | ✅ | □ | ✅ | ✅ | ✅ | □ | ✅ |
 | `lean_pq_sig_attestations_in_aggregated_signatures_total` | Counter | Total number of attestations included into aggregated signatures | On aggregated signature production | | | ✅ | □ | ✅ | □ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| `lean_pq_sig_aggregated_signatures_building_time_seconds` | Histogram | Time taken to build an aggregated attestation signature | On aggregated signature production | | 0.1, 0.25, 0.5, 0.75, 1, 1.25, 1.5, 2, 4 | ✅ | □ | 📝 | □ | ✅ | ✅ | ✅ | ✅ | 📝 |
+| `lean_pq_sig_aggregated_signatures_building_time_seconds` | Histogram | Time taken to build an aggregated attestation signature | On aggregated signature production | | 0.1, 0.25, 0.5, 0.75, 1, 1.25, 1.5, 2, 4 | ✅ | ✅ | 📝 | □ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | `lean_pq_sig_aggregated_signatures_verification_time_seconds` | Histogram | Time taken to verify an aggregated attestation signature | On aggregated signature verification | | 0.1, 0.25, 0.5, 0.75, 1, 1.25, 1.5, 2, 4 | ✅ | □ | 📝 | □ | ✅ | ✅ | ✅ | ✅ | 📝 |
 
 ## Block Production Metrics
@@ -85,6 +85,7 @@
 | `lean_validators_count` | Gauge | Number of validators managed by a node | On scrape |  | | ✅ | □ | ✅ | □ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | `lean_is_aggregator` | Gauge | Validator's `is_aggregator` status. True=1, False=0 | On node start |  | | ✅ | □ | ✅ | □ | ✅ | ✅ | ✅ | ✅ | □ |
 | `lean_attestations_production_time_seconds` | Histogram | Time taken to produce attestation | On attestation production | | 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 0.75, 1 | □ | □ | □ | □ | □ | □ | □ | □ | □ |
+| `lean_aggregator_skipped_total` | Counter | Total number of aggregation submissions skipped, labeled by reason. Use to attribute missed aggregations: distinguish "had no duty this slot" (`not_aggregator`) from genuine misses (`not_synced` when wall-lag gates aggregation, `missing_state` when pre-state isn't resolvable, `spawn_failed` when the aggregation worker queue is full, `other` for anything not covered above). Sum across labels = total aggregation cycles seen. | On aggregation cycle exit | reason=not_aggregator,not_synced,missing_state,spawn_failed,other | | □ | □ | □ | □ | □ | □ | □ | □ | 📝 |
 
 ## Network Metrics
 


### PR DESCRIPTION
## Summary

Adds a new cross-client metric `lean_aggregator_skipped_total{reason=...}` so operators can answer "how many slots did aggregation actually run for, and how many were skipped and why?" with a single counter rather than deriving the answer from coverage gauges or grepping logs.

Also updates the existing `lean_pq_sig_aggregated_signatures_building_time_seconds` row to reflect what's actually exposed on the live devnet (Grandine and Zeam).

## Motivation

Today no client exposes a standard skip counter. Operators surveying the live devnet found:

- **zeam** exposes `zeam_aggregate_skip_total{reason=not_aggregator|not_synced|missing_state|spawn_failed}` (client-namespaced)
- **ream / grandine / ethlambda / lantern** expose nothing equivalent

That leaves "did this aggregator drop a slot?" as a derived question. The two indirect proxies — per-slot subnet coverage (`lean_attestation_aggregate_coverage_subnets`) and `lean_pq_sig_aggregated_signatures_total` rate — both miss the "had-duty-and-silently-dropped" case, and the coverage gauge isn't even exposed by every client.

A first-class counter for skips ends the guesswork and makes "missed aggregations" comparable across the fleet.

## Proposed label values

| reason | When it fires |
|---|---|
| `not_aggregator` | This slot's aggregation duty wasn't ours. Bookkeeping — lets you separate "no duty" from "had duty but skipped" |
| `not_synced` | Wall-lag or sync-status gate prevented aggregation (e.g. node is in `behind_peers` and aggregation is gated) |
| `missing_state` | Pre-state for the att_data target couldn't be resolved when the aggregator ran |
| `spawn_failed` | Aggregation worker queue was full / spawn error |
| `other` | Catch-all so clients can adopt incrementally without enumerating every internal failure mode |

Sum across labels = total aggregation cycles seen. `sum by (reason) (rate(lean_aggregator_skipped_total[5m]))` then gives both the duty distribution and the genuine-miss rate.

## Status table

| Client | Status | Notes |
|---|---|---|
| Zeam | 📝 | Has equivalent counter under `zeam_aggregate_skip_total`; rename to `lean_aggregator_skipped_total` upstream-adoption |
| Others | □ | Not yet implemented |

## Drive-by updates

`lean_pq_sig_aggregated_signatures_building_time_seconds`:

- **Grandine: □ → ✅** — verified exposed on the live devnet (~600 observations on grandine_0 over a ~16 min run, p50≈1.19s)
- **Zeam: 📝 → ✅** — implemented in [zeam #941](https://github.com/blockblaz/zeam/pull/941), exposed on devnet image `sha256:bb801c18…`, ~500 observations per aggregator (p50≈0.38s)

## Test plan

- [x] Reviewed `metrics.md` rendering locally
- [ ] Reviewers confirm naming + label set is acceptable
- [ ] Reviewers from each client team confirm/correct the status table